### PR TITLE
Patch nvprof so it doesn't link outside the conda environment

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,7 +2,7 @@ build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64
 conda_build:
-  error_overlinking: false
+  error_overlinking: true
 conda_forge_output_validation: true
 github:
   branch_name: main

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -34,5 +34,9 @@ for i in `ls`; do
         # Leaving bin in PREFIX
         mkdir -p ${PREFIX}
         cp -rv $i ${PREFIX}
+        # we also need to patch bin/nvprof, it contains runpaths to system directories
+        if [[ $i == "bin" ]] && [[ -f "${i}/nvprof" ]]; then
+            patchelf --set-rpath '$ORIGIN/../lib' --force-rpath ${PREFIX}/$i/nvprof
+        fi
     fi
 done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
   sha256: bd434d759948b4ef9d9e663b89f5019ea104afec6bf7a17267c624b0bfbc1a03  # [win]
 
 build:
-  number: 1
+  number: 2
   binary_relocation: false
   skip: true  # [osx or aarch64]
   missing_dso_whitelist:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ build:
   missing_dso_whitelist:
     # This is a driver file, might be able to use cuda-compat to remove this
     - '*/libcuda.so.1'  # [linux]
+    - '*/libgcc_s.so.1' # [linux]
     - '*/nvcuda.dll'    # [win]
 
 requirements:
@@ -37,6 +38,7 @@ requirements:
   host:
     - cuda-version {{ cuda_version }}
     - cuda-cupti
+    - libstdcxx-ng      # [ppc64le]
   run:
     - {{ pin_compatible("cuda-version", max_pin="x.x") }}
     - cuda-cupti


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

When overlinking check is turned on, the following error message occurs:

```
ERROR (cuda-nvprof,bin/nvprof): runpaths ['$ORIGIN/../extras/CUPTI/lib64', '$ORIGIN/../targets/x86_64-linux/lib'] found in
/croot/cuda-nvprof_1715204971555/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_plac
ehold_placehold_placehold_placehold_place/bin/nvprof"
```
